### PR TITLE
Change: ジェネレートコマンドでルートとテストとヘルパーを生成しないように設定

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,0 +1,2 @@
+class UserController < ApplicationController
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,12 @@ module FlowerMapRails
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Don't generate roots and test and helper
+    config.generators do |g|
+      g.skip_routes true
+      g.test_framework false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
# 概要
rails gコマンドでルートとテストを生成しないように設定した。
# 確認事項
- modelとcontrollerのrails gコマンドでルートとテストとヘルパーが作成されない。
# 確認方法
- modelとcontrollerのrails gコマンドを実行する。
`bundle exec rails g model User`
`bundle exec rails g controller User`
以下のような画面になれば、大丈夫です。
- model(マイグレーションファイルとモデルファイルが作成される)
[![Image from Gyazo](https://i.gyazo.com/7855578da048bdd7c5c0608d7630403e.png)](https://gyazo.com/7855578da048bdd7c5c0608d7630403e)
- controller(コントローラファイルが作成される)
[![Image from Gyazo](https://i.gyazo.com/b75a0d7258cdd6618027390c8519ea98.png)](https://gyazo.com/b75a0d7258cdd6618027390c8519ea98)
# 懸念点

# 参考資料