### PR TITLE
Add: 投稿した花の編集/削除機能を追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  before_action :require_login
+
   def create
     @comment = current_user.comments.build(comment_params)
     if @comment.save

--- a/app/controllers/flowers_controller.rb
+++ b/app/controllers/flowers_controller.rb
@@ -29,7 +29,7 @@ class FlowersController < ApplicationController
   def edit; end
 
   def update
-    if @board.update(flower_params)
+    if @flower.update(flower_params)
       redirect_to @flower, success: '編集が完了しました！'
     else
       flash.now['danger'] = '編集が失敗しました'

--- a/app/controllers/flowers_controller.rb
+++ b/app/controllers/flowers_controller.rb
@@ -1,5 +1,6 @@
 class FlowersController < ApplicationController
   before_action :require_login
+  before_action :find_flower, only: %i[edit update destroy]
 
   def index
     @flowers = Flower.all.includes(:user).order(created_at: :desc)
@@ -25,9 +26,28 @@ class FlowersController < ApplicationController
     @comments = @flower.comments.includes(:user).order(created_at: :desc)
   end
 
+  def edit; end
+
+  def update
+    if @board.update(flower_params)
+      redirect_to @flower, success: '編集が完了しました！'
+    else
+      flash.now['danger'] = '編集が失敗しました'
+      render :edit
+    end
+  end
+
+  def destroy
+    @flower.destroy!
+    redirect_to flowers_path, success: '削除が完了しました！'
+  end
   private
 
   def flower_params
     params.require(:flower).permit(:name, :address, :datetime,:status, :flower_image, :flower_image_cache, :latitude, :longitude)
+  end
+
+  def find_flower
+    @flower = current_user.flowers.find(params[:id])
   end
 end

--- a/app/views/flowers/_crud_menus.html.erb
+++ b/app/views/flowers/_crud_menus.html.erb
@@ -1,0 +1,12 @@
+<ul class='flex justify-center p-4'>
+  <li>
+    <%= link_to edit_flower_path(flower), id: "button-edit-#{flower.id}" do %>
+      <%= image_tag 'pen.png', size: '36x36' %>
+    <% end %>
+  </li>
+  <li>
+    <%= button_to flower_path(flower), id: "button-delete-#{flower.id}", method: :delete, data: { confirm: '削除完了しました' } do %>
+      <%= image_tag 'trash.png', size: '36x36' %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/flowers/_flower.html.erb
+++ b/app/views/flowers/_flower.html.erb
@@ -11,6 +11,9 @@
           <p>時間: <%= flower.datetime %></p>
           <%= link_to "詳細画面へ", flower_path(flower), class: "btn btn-success" %>
         </div>
+        <div class="mt-48">
+          <%= render 'crud_menus', flower: flower if current_user.own?(flower) %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/flowers/edit.html.erb
+++ b/app/views/flowers/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content">
+    <div class="max-w-md">
+      <h1 class="text-3xl font-bold p-10 text-center">投稿画面</h1>
+      <%= render 'form', { flower: @flower } %>
+    </div>
+  </div>
+</div>

--- a/app/views/flowers/show.html.erb
+++ b/app/views/flowers/show.html.erb
@@ -22,8 +22,10 @@
       </label>
       <%= @flower.status %>
       <div class="flex my-4">
-        <%= render 'comments/form', { board: @flower, comment: @comment } %>
+        <%= render 'comments/form', { flower: @flower, comment: @comment } %>
         <%= render 'comments/comments', { comments: @comments } %>
+        <p class='text-2xl text-center mt-4'>編集/削除</p>
+        <%= render 'crud_menus', flower: @flower if current_user.own?(@flower) %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
       <%= link_to '#' do %>
         <%= image_tag 'mypage.png', width: '50%', height: '50%' %>
       <% end %>
-      <%= link_to logout_path do %>
+      <%= button_to logout_path, method: :delete do %>
         <%= image_tag 'logout.png', width: '50%', height: '50%' %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
-  get 'logout', to: 'user_sessions#destroy'
+  delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
   resources :flowers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :flowers, only: %i[index new create show] do
+  resources :flowers do
     resources :comments, only: %i[create], shallow: true
   end
 end


### PR DESCRIPTION
# 概要
投稿した花の編集機能と削除機能を追加しました。
- 編集と削除のrouteを作成
- コントローラに編集と削除を追加
- ビューを作成。一覧画面と詳細画面に編集ボタンと削除ボタンを追加

link_toではdeleteリクエストを送れなかったので、button_toで代用している。
# 確認事項
花の投稿に編集と削除ができるか確認。
# 確認方法
一覧画面と詳細画面で編集と削除ができるか確認する。
[![Image from Gyazo](https://i.gyazo.com/d9ad15961986caf628bf7453bb11f73d.png)](https://gyazo.com/d9ad15961986caf628bf7453bb11f73d)
[![Image from Gyazo](https://i.gyazo.com/06ac34f0ad50bb7f35a601cc0d796d4a.png)](https://gyazo.com/06ac34f0ad50bb7f35a601cc0d796d4a)
# 懸念点
# 参考資料
https://jsnotice.com/posts/2020-04-30/
https://qiita.com/oden-09/items/39473d8f510cf70a52e8
https://qiita.com/sijiaoh/items/973f9f7d91d669a79ef5
https://qiita.com/jnchito/items/5c41a7031404c313da1f#destroy%E3%81%AE%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%AB-status-see_other-%E3%82%92%E4%BB%98%E3%81%91%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B