### PR TITLE
Update: Herokuへデプロイする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.6.2)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
@@ -292,6 +294,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.5.4-x86_64-darwin)
+    sqlite3 (1.5.4-x86_64-linux)
     ssrf_filter (1.0.8)
     thor (1.2.1)
     tilt (2.0.11)
@@ -320,6 +323,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   better_errors

--- a/app/views/flowers/edit.html.erb
+++ b/app/views/flowers/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content">
     <div class="max-w-md">
-      <h1 class="text-3xl font-bold p-10 text-center">投稿画面</h1>
+      <h1 class="text-3xl font-bold p-10 text-center">編集画面</h1>
       <%= render 'form', { flower: @flower } %>
     </div>
   </div>


### PR DESCRIPTION
# 概要
herokuへの以下の手順でherokuへのデプロイを行いました。
- herokuのdynoプランとpostgre MINIプランに加入
- `heroku login`する
- `heroku push heroku heroku_deploy:master`でデプロイ
- `heroku run rails db:migrate'でデータベースの作成。
- 
# 確認事項
herokuにデプロイで来ている確認
# 確認方法
https://flower-map.herokuapp.com/
上記のURLで確認できる。
# 懸念点
top画面の写真のストレージを確保しなきゃいけない。
# 参考資料
https://school.runteq.jp/v2/curriculums/infra_advanced/chapters/4
https://reasonable-code.com/heroku-plan-change/
https://blog.jnito.com/entry/2022/11/08/084938
https://qiita.com/fujiab/items/ca79dabad06bbd75ba39
https://qiita.com/m6mmsf/items/fb8a8672df98bdb59c9c
https://qiita.com/koda_7932/items/63061c197aabf1dafb0e
https://www.reddit.com/r/rails/comments/rizxn7/rails_7_asset_pipeline_sasscsyntaxerror_with/
https://qiita.com/tofuminto/items/4bc016db484fdc4e9ee7