### PR TITLE
Add: 詳細画面と一覧画面のステータスを星の表記に変えた。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,3 +98,6 @@ gem 'rails-i18n'
 
 # Rails and javascript integration
 gem 'gon'
+
+# enum_view
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -349,6 +351,7 @@ DEPENDENCIES
   carrierwave
   cssbundling-rails
   dotenv-rails
+  enum_help
   factory_bot_rails
   faker
   gon

--- a/app/views/flowers/_flower.html.erb
+++ b/app/views/flowers/_flower.html.erb
@@ -12,7 +12,7 @@
           <h3 class="font-bold"><%= t 'defaults.time' %></h3>
           <p><%= l flower.datetime %></p>
           <h3 class="font-bold"><%= t 'defaults.status' %></h3>
-          <p><%= flower.status %></p>
+          <p><%= flower.status_i18n %></p>
           <%= link_to (t 'defaults.detail_screen'), flower_path(flower), class: "btn btn-success" %>
         </div>
         <div class="mt-48">

--- a/app/views/flowers/show.html.erb
+++ b/app/views/flowers/show.html.erb
@@ -18,7 +18,7 @@
       <label class="label">
         <span class="label-text"><%= t '.status' %></span>
       </label>
-      <%= @flower.status %>
+      <%= @flower.status_i18n %>
       <div class="flex my-4">
         <%= render 'comments/form', { flower: @flower, comment: @comment } %>
         <%= render 'comments/comments', { comments: @comments } %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,3 +30,11 @@ ja:
         address: "東京駅"
         calender: "左のカレンダーから入力しよう！"
         dummy_flower: "ヒマワリ"
+  enums:
+    flower:
+      status:
+        bad: "⭐☆☆☆☆"
+        rather_bad: "⭐⭐☆☆☆"
+        usually: "⭐⭐⭐☆☆"
+        good: "⭐⭐⭐⭐☆"
+        beautiful: "⭐⭐⭐⭐⭐"


### PR DESCRIPTION
# 概要
flwoerモデルのstatusを星表記に変えました。

 - gem enum_helpをインストール
 - localeに翻訳をのせる
 - ステータスのビューをi18nに変更。

# 確認事項
星表記になっている確認。
# 確認方法
詳細画面と一覧画面のステータスを見る。
[![Image from Gyazo](https://i.gyazo.com/cd76a56318961860b32051caca4205d7.png)](https://gyazo.com/cd76a56318961860b32051caca4205d7)
[![Image from Gyazo](https://i.gyazo.com/fb06dffd85d98cc9babbeda5162b671a.png)](https://gyazo.com/fb06dffd85d98cc9babbeda5162b671a)
# 懸念点
当初はraty.jsやjqueryで実装を行おうとしたが、導入に躓き、enum_helpで代用する形になった。
# 参考資料
https://qiita.com/kikikikimorimori/items/353f69e31b42e85b9c29