### PR TITLE
Update: 画像の保存先をAmazonS3に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,3 +104,4 @@ gem 'enum_help'
 
 # Amazon_S3 image storage
 gem 'fog-aws'
+gem "aws-sdk-s3", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,6 @@ gem 'gon'
 
 # enum_view
 gem 'enum_help'
+
+# Amazon_S3 image storage
+gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,22 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.700.0)
+    aws-sdk-core (3.170.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.62.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.118.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -161,6 +177,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
@@ -362,6 +379,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.11.0)
+    excon (0.97.2)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -128,6 +129,22 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    fog-aws (3.15.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     gon (6.4.0)
@@ -171,6 +188,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
@@ -354,6 +374,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   faker
+  fog-aws
   gon
   jbuilder
   jsbundling-rails

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,8 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/flower_image_uploader.rb
+++ b/app/uploaders/flower_image_uploader.rb
@@ -4,8 +4,8 @@ class FlowerImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/flower_image_uploader.rb
+++ b/app/uploaders/flower_image_uploader.rb
@@ -4,8 +4,11 @@ class FlowerImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -10,8 +10,8 @@ CarrierWave.configure do |config|
     config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1',
       path_style: true
     }

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'flower-map'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1',
+      path_style: true
+    }
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,14 +3,20 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
+  if Rails.env.production? # 本番環境の場合はS3へアップロード
     config.storage :fog
     config.fog_provider = 'fog/aws'
-    config.fog_directory  = 'flower-map'
+    config.fog_directory  = 'mitsuboshibucket'
+    config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1',
       path_style: true
     }
+  else # 本番環境以外の場合はアプリケーション内にアップロード
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,7 @@ CarrierWave.configure do |config|
   if Rails.env.production? # 本番環境の場合はS3へアップロード
     config.storage :fog
     config.fog_provider = 'fog/aws'
-    config.fog_directory  = 'mitsuboshibucket'
+    config.fog_directory  = 'flower-map'
     config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,13 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
+amazon:
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: ap-northeast-1
+  bucket: flower-map
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
# 概要
avatarとflower_imageの画像の保存によるストレージの圧迫を避けるため、外部ストレージに保存する。

AWS側の設定
1. IAMユーザーの作成
2. S3パケットの作成
3. パケットポリシーの追加

ファイルを設定

1. Carrierwaveにfog-awsを追加
2. アップローダーのストレージを変更。
3. IAMユーザーとバケットの情報を設定する
4. 環境変数の設定
5. .envファイルをgitignoreに記述

# 確認事項
AWSに画像が保存されているか。
# 確認方法
ご自身のAWSにて確認
# 懸念点
# 参考資料
https://pikawaka.com/rails/carrierwave
https://github.com/shutorm02/mitsuboshi_powder_rooms
https://take-engineer.com/the-bucket-does-not-allow-acls/
https://qiita.com/NetaNeta0620/questions/262c01801baf6b243151
https://style.potepan.com/articles/35403.html#:~:text=Identity%20And%20Access%20Management(IAM,%E4%BD%9C%E6%88%90%E3%82%92%E3%82%AF%E3%83%AA%E3%83%83%E3%82%AF%E3%81%97%E3%81%BE%E3%81%99%E3%80%82
https://qiita.com/sayama0402/items/e2c9e65786259dc55e11