### PR TITLE
Fix: お気に入り登録ボタンにタッチできないバグを修正

### DIFF
--- a/app/views/flowers/_favorite.html.erb
+++ b/app/views/flowers/_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip tooltip-bottom" data-tip=<%= t 'defaults.favorite' %>>
-  <%= button_to favorites_path(flower_id: flower.id), method: :post do %>
+  <%= link_to favorites_path(flower_id: flower.id), data: { turbo_method: :post } do %>
     <%= image_tag 'clover-white.png', class: "w-7 h-7" %>
   <% end %>
 </div>

--- a/app/views/flowers/_unfavorite.html.erb
+++ b/app/views/flowers/_unfavorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip tooltip-bottom" data-tip=<%= t 'defaults.unfavorite' %>>
-  <%= button_to favorite_path(current_user.favorites.find_by(flower_id: flower.id)), method: :delete do %>
+  <%= link_to favorite_path(current_user.favorites.find_by(flower_id: flower.id)), data: { turbo_method: :delete } do %>
     <%= image_tag 'clover.png', class: "w-7 h-7" %>
   <% end %>
 </div>


### PR DESCRIPTION
# 概要
turbo-railsのgemを導入した影響か、タッチしてもお気に入りにならないバグが発生していたので、直した。
# 確認事項
お気に入り機能が機能しているか
# 確認方法
一覧画面にて確認。
# 懸念点
# 参考資料