### PR TITLE
Fix: 地図の機能のバグを削除

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
-import "./controllers"
+// import "@hotwired/turbo-rails"
+// import "./controllers"

--- a/app/views/unknown_flowers/show.html.erb
+++ b/app/views/unknown_flowers/show.html.erb
@@ -1,7 +1,6 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content">
     <div class="max-w-md">
-      <%= render 'reception_badge', unknown_flower: @unknown_flower %>
       <h1 class="sm:text-4xl text-3xl font-serif p-10 text-center text-accent-focus"><%= t '.title' %></h1>
       <%= image_tag @unknown_flower.image_url, class: "rounded-xl sm:w-96 sm:h-96 w-80 h-80 mt-3" %>
       <% if @unknown_flower.date %>


### PR DESCRIPTION
# 概要

```
Uncaught SyntaxError: Identifier 'map' has already been declared (at google_map-94e554e0b956fc41359afde375c035365c21ddbb9f8c31ef2b04a358843a3402.js:1:1)
```
というエラーが出ており、前のページの地図のjavascriptを読み込んでしまっていまい、今いるページの地図機能が使えなくなっていた。
原因は前にインストールしたhotwireが干渉していてエラーが起ったとわかった。
なので

1. application.jsでimportしていたhotwireの機能を切る
2. 質問バッジ機能を切る。

以下の作業を行うことで地図の機能は無事に処理が動くようになった。

# 確認事項
前の地図の機能を引き継いでいないか
# 確認方法
ハナノ投稿画面から詳細画面に行っていただくと、確認できます。
# 懸念点
hotwireの機能を使えないのなら、非同期処理ができない。
# 参考資料