### PR TITLE
Fix: お気に入り機能を押しても、リクエストできないバグを削除

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,7 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: %i[edit update]
+  before_action :set_user, only: %i[show edit update]
+
+  def show; end
 
   def edit; end
 

--- a/app/views/flowers/_favorite.html.erb
+++ b/app/views/flowers/_favorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip tooltip-bottom" data-tip=<%= t 'defaults.favorite' %>>
-  <%= link_to favorites_path(flower_id: flower.id), data: { turbo_method: :post } do %>
+  <%= button_to favorites_path(flower_id: flower.id), method: :post do %>
     <%= image_tag 'clover-white.png', class: "w-7 h-7" %>
   <% end %>
 </div>

--- a/app/views/flowers/_unfavorite.html.erb
+++ b/app/views/flowers/_unfavorite.html.erb
@@ -1,5 +1,5 @@
 <div class="tooltip tooltip-bottom" data-tip=<%= t 'defaults.unfavorite' %>>
-  <%= link_to favorite_path(current_user.favorites.find_by(flower_id: flower.id)), data: { turbo_method: :delete } do %>
+  <%= button_to favorite_path(current_user.favorites.find_by(flower_id: flower.id)), method: :delete do %>
     <%= image_tag 'clover.png', class: "w-7 h-7" %>
   <% end %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -11,11 +11,7 @@
             <div>
               <h2 class="sm:text-xl text-base font-serif font-bold"><%= current_user.name %></h2>
               <p class="sm:text-base text-xs"><%= current_user.email %></p>
-              <%= link_to edit_profile_path do %>
-                <div class="btn btn-primary sm:btn-sm btn-xs font-light mt-2 w-28">
-                  <%= t('defaults.edit') %>
-                </div>
-              <% end %>
+              <%= link_to t('defaults.edit'), edit_profile_path, class: "btn btn-primary sm:btn-sm btn-xs font-light mt-2 w-28" %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# 概要
お気に入り機能を押しても登録されないバグを修正。

turbo-railsの機能を消したため、link_toのpostメソッドが送れないという問題が起こっていたため、button_toに切り替えました。
# 確認事項
お気に入り機能が使えるか。
# 確認方法
一覧画面にて確認できます。
# 懸念点
# 参考資料