### PR TITLE
Fix: entrypoint.shを変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,5 @@
 set -e
 
-bin/rails css:install:tailwind
-bin/rails javascript:install:esbuild
-yarn add daisyui
 bin/rails db:migrate
 
 rm -f tmp/pids/server.pid && bin/dev


### PR DESCRIPTION
# 概要
magiaのデプロイは成功したが、アプリケーションエラーが発生したため、
entrypoint.shの記述を元のフォーマットに戻した。
# 確認事項
# 確認方法
# 懸念点
# 参考資料