### PR TITLE
Fix: entrypoint.shを変更

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@ set -e
 
 bin/rails db:migrate
 
-rm -f tmp/pids/server.pid && bin/dev
+rm -f tmp/pids/server.pid && bin/rails s


### PR DESCRIPTION
# 概要
entrypoint.shをデフォルトに戻した。formatエラーに対応するため。

# 確認事項
# 確認方法
# 懸念点
# 参考資料
https://school.runteq.jp/v2/mypage/helps/articles/runteq_magia?gretel_word=%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA%E9%96%A2%E9%80%A3#%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E5%85%88%E3%81%AE%E7%99%BB%E9%8C%B2